### PR TITLE
TypeError when running command with missing package

### DIFF
--- a/src/Command/UnpackCommand.php
+++ b/src/Command/UnpackCommand.php
@@ -51,7 +51,7 @@ class UnpackCommand extends BaseCommand {
     $op = new Operation(true, $input->getOption('sort-packages') || $composer->getConfig()->get('sort-packages'));
     $package = reset($packages);
     if (null === $pkg = $installedRepo->findPackage($package, '*')) {
-      $io->writeError(sprintf('<error>Package %s is not installed</>', $package['name']));
+      $io->writeError(sprintf('<error>Package %s is not installed</>', $package));
       return 1;
     }
 


### PR DESCRIPTION
Steps to reproduce:

1. Run unpack command with a package name that is not installed, example: `composer unpack missing/package`
2.  Will get error:  

```
In UnpackCommand.php line 54:
                                                 
  [TypeError]                                    
  Cannot access offset of type string on string  
                                                 

```

Should get:
`Package missing/package is not installed`

Patch should fix it.